### PR TITLE
rxdart and google_maps_webservice dependency upgrades

### DIFF
--- a/lib/src/flutter_google_places.dart
+++ b/lib/src/flutter_google_places.dart
@@ -356,7 +356,7 @@ abstract class PlacesAutocompleteState extends State<PlacesAutocompleteWidget> {
     _queryTextController.addListener(_onQueryChange);
 
     _queryBehavior.stream
-        .debounce(const Duration(milliseconds: 300))
+        .debounceTime(const Duration(milliseconds: 300))
         .listen(doSearch);
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  rxdart: ^0.21.0
+  rxdart: ^0.22.0
   google_maps_webservice: ^0.0.10
   http: ">=0.11.0 <1.0.0"
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,13 +5,13 @@ author: Hadrien Lejard <hadrien.lejard@gmail.com>
 homepage: https://github.com/lejard-h/flutter_google_places
 
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: ">=2.0.0 <3.0.0"
 
 dependencies:
   flutter:
     sdk: flutter
   rxdart: ^0.22.0
-  google_maps_webservice: ^0.0.10
+  google_maps_webservice: ^0.0.14
   http: ">=0.11.0 <1.0.0"
 
 dev_dependencies:


### PR DESCRIPTION
* `rxdart` was upgraded to version [0.22.0](https://pub.dev/packages/rxdart#0220) to resolve issues #58 and #60.
* `google_maps_webservice` was also upgraded from 0.0.10 to [0.0.14](https://pub.dev/packages/google_maps_webservice#0014).