### PR TITLE
Updates RxDart to 0.22.0

### DIFF
--- a/lib/src/flutter_google_places.dart
+++ b/lib/src/flutter_google_places.dart
@@ -356,7 +356,7 @@ abstract class PlacesAutocompleteState extends State<PlacesAutocompleteWidget> {
     _queryTextController.addListener(_onQueryChange);
 
     _queryBehavior.stream
-        .debounce(const Duration(milliseconds: 300))
+        .debounceTime(const Duration(milliseconds: 300))
         .listen(doSearch);
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,16 +1,16 @@
 name: flutter_google_places
 description: Google places autocomplete widgets for flutter. No wrapper, use https://pub.dartlang.org/packages/google_maps_webservice
-version: 0.2.2
+version: 0.2.3
 author: Hadrien Lejard <hadrien.lejard@gmail.com>
 homepage: https://github.com/lejard-h/flutter_google_places
 
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: ">=2.0.0 <3.0.0"
 
 dependencies:
   flutter:
     sdk: flutter
-  rxdart: ^0.21.0
+  rxdart: ^0.22.0
   google_maps_webservice: ^0.0.10
   http: ">=0.11.0 <1.0.0"
 


### PR DESCRIPTION
I change the version of rxdart and change the debounce function to debounceTime so that the code works with rxdart 0.22.0, this is neccessaire for the library to cohesist with flutter_bloc