### PR TITLE
make debounce configurable. debounce calls to API

### DIFF
--- a/lib/src/flutter_google_places.dart
+++ b/lib/src/flutter_google_places.dart
@@ -116,7 +116,7 @@ class _PlacesAutocompleteOverlayState extends PlacesAutocompleteState {
           )
     ]);
 
-    var body;
+    Widget body;
 
     if (_searching) {
       body = Stack(
@@ -168,7 +168,7 @@ class _PlacesAutocompleteOverlayState extends PlacesAutocompleteState {
     return container;
   }
 
-  Icon get _iconBack => -Theme.of(context).platform == TargetPlatform.iOS
+  Icon get _iconBack => Theme.of(context).platform == TargetPlatform.iOS
       ? Icon(Icons.arrow_back_ios): Icon(Icons.arrow_back);
 
 


### PR DESCRIPTION
Putting a debounce on the `_queryBehavior.stream` wasn't working for me. It was still calling the API as quickly as I was typing. I was getting lots of rate limit errors. This solution seems to do the trick.