### PR TITLE
Add to support app restricted API keys

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,14 +1,12 @@
 import 'dart:async';
 
+import 'package:google_api_headers/google_api_headers.dart';
 import 'package:google_maps_webservice/places.dart';
 import 'package:flutter_google_places/flutter_google_places.dart';
 import 'package:flutter/material.dart';
 import 'dart:math';
 
 const kGoogleApiKey = "API_KEY";
-
-// to get places detail (lat/lng)
-GoogleMapsPlaces _places = GoogleMapsPlaces(apiKey: kGoogleApiKey);
 
 main() {
   runApp(RoutesWidget());
@@ -123,6 +121,10 @@ class _MyAppState extends State<MyApp> {
 Future<Null> displayPrediction(Prediction p, ScaffoldState scaffold) async {
   if (p != null) {
     // get detail (lat/lng)
+    GoogleMapsPlaces _places = GoogleMapsPlaces(
+      apiKey: kGoogleApiKey,
+      apiHeaders: await GoogleApiHeaders().getHeaders(),
+    );
     PlacesDetailsResponse detail = await _places.getDetailsByPlaceId(p.placeId);
     final lat = detail.result.geometry.location.lat;
     final lng = detail.result.geometry.location.lng;

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -4,20 +4,19 @@ description: A new Flutter project.
 dependencies:
   flutter:
     sdk: flutter
+  flutter_google_places:
+    path: ../
+  google_api_headers: ^0.1.1+1
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_google_places:
-    path: ../
-
 
 # For information on the generic Dart part of this file, see the
 # following page: https://www.dartlang.org/tools/pub/pubspec
 
 # The following section is specific to Flutter.
 flutter:
-
   # The following line ensures that the Material Icons font is
   # included with your application, so that you can use the icons in
   # the Icons class.

--- a/lib/src/flutter_google_places.dart
+++ b/lib/src/flutter_google_places.dart
@@ -3,6 +3,7 @@ library flutter_google_places.src;
 import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:google_api_headers/google_api_headers.dart';
 import 'package:google_maps_webservice/places.dart';
 import 'package:http/http.dart';
 import 'package:rxdart/rxdart.dart';
@@ -386,10 +387,7 @@ abstract class PlacesAutocompleteState extends State<PlacesAutocompleteWidget> {
     super.initState();
     _queryTextController = TextEditingController(text: widget.startText);
 
-    _places = GoogleMapsPlaces(
-        apiKey: widget.apiKey,
-        baseUrl: widget.proxyBaseUrl,
-        httpClient: widget.httpClient);
+    _initPlaces();
     _searching = false;
 
     _queryTextController.addListener(_onQueryChange);
@@ -397,8 +395,17 @@ abstract class PlacesAutocompleteState extends State<PlacesAutocompleteWidget> {
     _queryBehavior.stream.listen(doSearch);
   }
 
+  Future<void> _initPlaces() async {
+    _places = GoogleMapsPlaces(
+      apiKey: widget.apiKey,
+      baseUrl: widget.proxyBaseUrl,
+      httpClient: widget.httpClient,
+      apiHeaders: await GoogleApiHeaders().getHeaders(),
+    );
+  }
+
   Future<Null> doSearch(String value) async {
-    if (mounted && value.isNotEmpty) {
+    if (mounted && value.isNotEmpty && _places != null) {
       setState(() {
         _searching = true;
       });

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,10 @@ dependencies:
   flutter:
     sdk: flutter
   rxdart: ^0.24.0
-  google_maps_webservice: ^0.0.16
+  google_maps_webservice:
+    git:
+      url: https://github.com/zeshuaro/google_maps_webservice.git
+      ref: feature/restricted-api-keys
   http: ">=0.11.0 <1.0.0"
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,11 +12,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  google_maps_webservice:
-    git:
-      url: https://github.com/zeshuaro/google_maps_webservice.git
-      ref: feature/api-headers
   google_api_headers: ">=0.1.0 <1.0.0"
+  google_maps_webservice: ^0.0.19
   http: ">=0.11.0 <1.0.0"
   rxdart: ^0.24.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,6 @@
 name: flutter_google_places
-description: Google places autocomplete widgets for flutter. No wrapper, use https://pub.dartlang.org/packages/google_maps_webservice
+description: Google places autocomplete widgets for flutter. No wrapper, use
+  https://pub.dartlang.org/packages/google_maps_webservice
 version: 0.2.5
 author: Hadrien Lejard <hadrien.lejard@gmail.com>
 homepage: https://github.com/lejard-h/flutter_google_places
@@ -11,12 +12,13 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  rxdart: ^0.24.0
   google_maps_webservice:
     git:
       url: https://github.com/zeshuaro/google_maps_webservice.git
-      ref: feature/restricted-api-keys
+      ref: feature/api-headers
+  google_api_headers: ">=0.1.0 <1.0.0"
   http: ">=0.11.0 <1.0.0"
+  rxdart: ^0.24.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- Add [`google_api_headers`](https://pub.dev/packages/google_api_headers) as a dependency which provides the required headers for making API calls using app restricted API keys
- Add to support API keys that are restricted to iOS or Android apps
- Update `google_maps_webservice` to minimum version `0.0.19` for supporting custom API headers
- Update example app to also work with app restricted API keys
- Related issues #18 #127 #131 