### PR TITLE
Update flutter_google_places.dart

### DIFF
--- a/lib/src/flutter_google_places.dart
+++ b/lib/src/flutter_google_places.dart
@@ -71,7 +71,11 @@ class PlacesAutocompleteWidget extends StatefulWidget {
   }
 
   static PlacesAutocompleteState of(BuildContext context) =>
-      context.ancestorStateOfType(const TypeMatcher<PlacesAutocompleteState>());
+      
+      //context.ancestorStateOfType(const TypeMatcher<PlacesAutocompleteState>());// it is deprecated and should be as follows  to compile on latest flutter
+      context.findAncestorStateOfType<PlacesAutocompleteState>();
+
+  
 }
 
 class _PlacesAutocompleteScaffoldState extends PlacesAutocompleteState {


### PR DESCRIPTION
I am using 
Flutter 1.26.0-2.0.pre.396 • channel master • https://github.com/flutter/flutter.git
Framework • revision 319d3a511c (17 hours ago) • 2021-01-16 01:14:04 -0500
Engine • revision a243f4df07
Tools • Dart 2.12.0 (build 2.12.0-229.0.dev)

ancestorStateOfType is deprecated and need to be findAncestorStateOfType instead