### PR TITLE
fixing a cast error

### DIFF
--- a/lib/src/flutter_google_places.dart
+++ b/lib/src/flutter_google_places.dart
@@ -458,8 +458,8 @@ abstract class PlacesAutocompleteState extends State<PlacesAutocompleteWidget> {
   void dispose() {
     super.dispose();
 
-    _places!.dispose();
-    _debounce!.cancel();
+    _places?.dispose();
+    _debounce?.cancel();
     _queryBehavior.close();
     _queryTextController!.removeListener(_onQueryChange);
   }


### PR DESCRIPTION
Logs:
```
Null check operator used on a null value
flutter_google_places.dart in PlacesAutocompleteState.dispose at line 467 within flutter_google_places
```