### PR TITLE
Provide themeData and textStyle through optional parameters

### DIFF
--- a/lib/src/flutter_google_places.dart
+++ b/lib/src/flutter_google_places.dart
@@ -28,6 +28,7 @@ class PlacesAutocompleteWidget extends StatefulWidget {
   final int debounce;
   final InputDecoration? decoration;
   final TextStyle? textStyle;
+  final ThemeData? themeData;
 
   /// optional - sets 'proxy' value in google_maps_webservice
   ///
@@ -65,6 +66,7 @@ class PlacesAutocompleteWidget extends StatefulWidget {
     this.debounce = 300,
     this.decoration,
     this.textStyle,
+    this.themeData,
   }) : super(key: key);
 
   @override
@@ -78,21 +80,23 @@ class PlacesAutocompleteWidget extends StatefulWidget {
 class _PlacesAutocompleteOverlayState extends PlacesAutocompleteState {
   @override
   Widget build(BuildContext context) {
+    final theme = widget.themeData ?? Theme.of(context);
     if (widget.mode == Mode.fullscreen) {
-      return Scaffold(
-          appBar: AppBar(
-            title: AppBarPlacesAutoCompleteTextField(
-              textDecoration: widget.decoration,
-              textStyle: widget.textStyle,
+      return Theme(
+        data: theme,
+        child: Scaffold(
+            appBar: AppBar(
+              title: AppBarPlacesAutoCompleteTextField(
+                textDecoration: widget.decoration,
+                textStyle: widget.textStyle,
+              ),
             ),
-          ),
-          body: PlacesAutocompleteResult(
-            onTap: Navigator.of(context).pop,
-            logo: widget.logo,
-          ));
+            body: PlacesAutocompleteResult(
+              onTap: Navigator.of(context).pop,
+              logo: widget.logo,
+            )),
+      );
     } else {
-      final theme = Theme.of(context);
-
       final headerTopLeftBorderRadius = widget.overlayBorderRadius != null
           ? widget.overlayBorderRadius!.topLeft
           : const Radius.circular(2);
@@ -513,6 +517,7 @@ class PlacesAutocomplete {
     InputDecoration? decoration,
     String startText = "",
     TextStyle? textStyle,
+    ThemeData? themeData,
   }) {
     builder(BuildContext ctx) => PlacesAutocompleteWidget(
           apiKey: apiKey,
@@ -535,6 +540,7 @@ class PlacesAutocomplete {
           startText: startText,
           decoration: decoration,
           textStyle: textStyle,
+          themeData: themeData,
         );
 
     if (mode == Mode.overlay) {

--- a/lib/src/flutter_google_places.dart
+++ b/lib/src/flutter_google_places.dart
@@ -27,6 +27,7 @@ class PlacesAutocompleteWidget extends StatefulWidget {
   final ValueChanged<PlacesAutocompleteResponse>? onError;
   final int debounce;
   final InputDecoration? decoration;
+  final TextStyle? textStyle;
 
   /// optional - sets 'proxy' value in google_maps_webservice
   ///
@@ -63,6 +64,7 @@ class PlacesAutocompleteWidget extends StatefulWidget {
     this.startText,
     this.debounce = 300,
     this.decoration,
+    this.textStyle,
   }) : super(key: key);
 
   @override
@@ -81,6 +83,7 @@ class _PlacesAutocompleteOverlayState extends PlacesAutocompleteState {
           appBar: AppBar(
             title: AppBarPlacesAutoCompleteTextField(
               textDecoration: widget.decoration,
+              textStyle: widget.textStyle,
             ),
           ),
           body: PlacesAutocompleteResult(
@@ -509,6 +512,7 @@ class PlacesAutocomplete {
     Client? httpClient,
     InputDecoration? decoration,
     String startText = "",
+    TextStyle? textStyle,
   }) {
     builder(BuildContext ctx) => PlacesAutocompleteWidget(
           apiKey: apiKey,
@@ -530,6 +534,7 @@ class PlacesAutocomplete {
           httpClient: httpClient as BaseClient?,
           startText: startText,
           decoration: decoration,
+          textStyle: textStyle,
         );
 
     if (mode == Mode.overlay) {

--- a/lib/src/flutter_google_places.dart
+++ b/lib/src/flutter_google_places.dart
@@ -373,7 +373,10 @@ class PredictionTile extends StatelessWidget {
   Widget build(BuildContext context) {
     return ListTile(
       leading: const Icon(Icons.location_on),
-      title: Text(prediction.description!),
+      title: Text(
+        prediction.description!,
+        style: Theme.of(context).textTheme.bodyText2,
+      ),
       onTap: () {
         if (onTap != null) {
           onTap!(prediction);


### PR DESCRIPTION
Thank you for this package!

Apps with a light theme can have full white background and in those cases, texts are not visible when performing the search on full-screen mode. I tried wrapping the Scaffold on a Theme widget, but still the search was using the global theme.

This PR provides a theme through an optional parameter in the show function. This would allow developers to override any attribute to the theme.

As a bonus, I noticed that the textStyle attribute was not provided either through the show function. I also added it.

I think these changes should fix the following issues at least:

https://github.com/fluttercommunity/flutter_google_places/issues/89
https://github.com/fluttercommunity/flutter_google_places/issues/76