### PR TITLE
Bump google_api_headers to 1.3.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  google_api_headers: ^1.2.0
+  google_api_headers: ^1.3.0
   google_maps_webservice: ^0.0.20-nullsafety.5
   http: ^0.13.4
   rxdart: ^0.27.3


### PR DESCRIPTION
This will fix errors when trying to build with Flutter 3